### PR TITLE
Add another validate-config hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,15 @@
     language: script
     always_run: true
     args: [upstream_url]
+
 -   id: validate-config
+    name: Validate package config
+    description: Check for missing values and incorrect types
+    entry: ./pre-commit-hooks/validate-config.sh
+    language: script
+    files: ^\.?packit.ya?ml$
+
+-   id: validate-config-in-container
     name: Validate package config
     description: Check for missing values and incorrect types
     entry: quay.io/packit/packit:latest packit -d validate-config

--- a/README.md
+++ b/README.md
@@ -3,16 +3,38 @@ Our repo for managing pre-commit hooks
 
 ### Our hooks
 
-- `check-rebase` - Check if your branch is up to date with the upstream.
+- `check-rebase` - Check if your branch is up-to-date with the upstream.
     - Specify the url of the upstream repo in `args: [git://github...]`.
-
+- `validate-config` - Validate a [package config for Packit](https://packit.dev/docs/configuration).
+  - Requires `bash`.
+  - Runs the validation if there's a `packit` binary present.
+  - Passes if `packit` is not installed; this is useful if you can't install `packit` in the CI but still want to run the hook at least locally.
+- `validate-config-in-container` - Validate a [package config for Packit](https://packit.dev/docs/configuration).
+  - Uses [packit image](https://quay.io/repository/packit/packit) to run packit in a container.
+  - Requires `docker` binary to be present, which can be a problem for example in [pre-commit.ci](https://github.com/pre-commit-ci/issues/issues/11)
 
 ### Using check-rebase with pre-commit
 
 Add this to your `.pre-commit-config.yaml`
 
     -   repo: https://github.com/packit/pre-commit-hooks
-        rev: the revision or tag to clone at
+        rev: v1.2.0
         hooks:
-        -   id: check-rebase
+          - id: check-rebase
             args: [upstream_url]
+
+### Using validate-config with pre-commit
+
+Add this to your `.pre-commit-config.yaml`
+
+    -   repo: https://github.com/packit/pre-commit-hooks
+        rev: v1.2.0
+        hooks:
+          - id: validate-config
+
+or
+
+    -   repo: https://github.com/packit/pre-commit-hooks
+        rev: v1.2.0
+        hooks:
+          - id: validate-config-in-container

--- a/pre-commit-hooks/validate-config.sh
+++ b/pre-commit-hooks/validate-config.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+
+set -eu
+
+if command -v packit; then
+  packit -d validate-config
+else
+  echo "packit not installed, can't validate the config"
+  echo "either install packit or try the validate-config-in-container hook"
+fi


### PR DESCRIPTION
to run `packit validate-config` directly.
The previously added `validate-config` hook has been renamed to `validate-config-in-container`.

Fixes #36